### PR TITLE
Possibilidade de registrar adaptadores não hierárquicos (issue #1)

### DIFF
--- a/src/main/java/br/com/caelum/vraptor/deserialization/gson/GsonDeserialization.java
+++ b/src/main/java/br/com/caelum/vraptor/deserialization/gson/GsonDeserialization.java
@@ -14,6 +14,7 @@ import br.com.caelum.vraptor.deserialization.Deserializer;
 import br.com.caelum.vraptor.deserialization.Deserializes;
 import br.com.caelum.vraptor.http.ParameterNameProvider;
 import br.com.caelum.vraptor.resource.ResourceMethod;
+import br.com.caelum.vraptor.serialization.gson.HierarchicalAdapter;
 import br.com.caelum.vraptor.view.ResultException;
 
 import com.google.gson.Gson;
@@ -81,7 +82,13 @@ public class GsonDeserialization implements Deserializer {
 		GsonBuilder builder = new GsonBuilder();
 
 		for (JsonDeserializer<?> adapter : adapters) {
-			builder.registerTypeHierarchyAdapter(getAdapterType(adapter), adapter);
+			Class<?> adapterType = getAdapterType(adapter);
+			boolean isHierarchical = adapter.getClass().isAnnotationPresent(HierarchicalAdapter.class);
+			if (isHierarchical) {
+				builder.registerTypeHierarchyAdapter(adapterType, adapter);				
+			} else {
+				builder.registerTypeAdapter(adapterType, adapter);
+			}
 		}
 
 		return builder.create();

--- a/src/main/java/br/com/caelum/vraptor/serialization/gson/HierarchicalAdapter.java
+++ b/src/main/java/br/com/caelum/vraptor/serialization/gson/HierarchicalAdapter.java
@@ -1,0 +1,12 @@
+package br.com.caelum.vraptor.serialization.gson;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HierarchicalAdapter {
+
+}

--- a/src/main/java/br/com/caelum/vraptor/serialization/gson/VraptorGsonBuilder.java
+++ b/src/main/java/br/com/caelum/vraptor/serialization/gson/VraptorGsonBuilder.java
@@ -55,7 +55,13 @@ public class VraptorGsonBuilder {
 
 	public Gson create() {
 		for (JsonSerializer<?> adapter : serializers) {
-			builder.registerTypeHierarchyAdapter(getAdapterType(adapter), adapter);
+			Class<?> adapterType = getAdapterType(adapter);
+			boolean isHierarchical = adapter.getClass().isAnnotationPresent(HierarchicalAdapter.class);
+			if (isHierarchical) {
+				builder.registerTypeHierarchyAdapter(adapterType, adapter);				
+			} else {
+				builder.registerTypeAdapter(adapterType, adapter);
+			}
 		}
 
 		return builder.create();

--- a/src/main/java/br/com/caelum/vraptor/serialization/gson/adapters/CalendarSerializer.java
+++ b/src/main/java/br/com/caelum/vraptor/serialization/gson/adapters/CalendarSerializer.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Type;
 import java.util.Calendar;
 
 import br.com.caelum.vraptor.ioc.Component;
+import br.com.caelum.vraptor.serialization.gson.HierarchicalAdapter;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
@@ -11,6 +12,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
 @Component
+@HierarchicalAdapter
 public class CalendarSerializer implements JsonSerializer<Calendar> {
 
 	public JsonElement serialize(Calendar calendar, Type typeOfSrc, JsonSerializationContext context) {

--- a/src/main/java/br/com/caelum/vraptor/serialization/gson/adapters/HibernateProxySerializer.java
+++ b/src/main/java/br/com/caelum/vraptor/serialization/gson/adapters/HibernateProxySerializer.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Type;
 import org.hibernate.proxy.HibernateProxy;
 
 import br.com.caelum.vraptor.ioc.Component;
+import br.com.caelum.vraptor.serialization.gson.HierarchicalAdapter;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -12,6 +13,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
 @Component
+@HierarchicalAdapter
 public class HibernateProxySerializer implements JsonSerializer<HibernateProxy> {
 
 	public JsonElement serialize(HibernateProxy proxyObj, Type type, JsonSerializationContext ctx) {

--- a/src/test/java/br/com/caelum/vraptor/serialization/gson/GsonJSONSerializationTest.java
+++ b/src/test/java/br/com/caelum/vraptor/serialization/gson/GsonJSONSerializationTest.java
@@ -507,4 +507,63 @@ public class GsonJSONSerializationTest {
 
 		assertThat(result(), not(containsString("address")));
 	}
+	
+	@Test
+	public void shouldUseHierarchicalAdapterWhenItExists() {
+		String expectedResult = "{\"list\":[\"Order\",\"Order\"]}";
+		
+		Order order = new Order(null, 15.0, "pack it nicely, please");		
+		Order advancedOrder = new AdvancedOrder(null, 15.0, "pack it nicely, please", "complex package");		
+		List<Order> orders = Arrays.asList(order, advancedOrder);
+		
+		List<JsonSerializer<?>> adapters = new ArrayList<JsonSerializer<?>>();
+		adapters.add(new MyHierarchicalAdapter());
+
+		GsonJSONSerialization serialization = new GsonJSONSerialization(response,
+				extractor,
+				initializer,
+				adapters);
+		
+		serialization.from(orders).serialize();
+		assertThat(result(), is(equalTo(expectedResult)));		
+	}
+	
+	@Test
+	public void shouldUseNonHierarchicalAdapterWhenItExists() {
+		String expectedResult = "{\"list\":[\"Order\",{\"notes\":\"complex package\",\"price\":15.0,\"comments\":\"pack it nicely, please\"}]}";
+		
+		Order order = new Order(null, 15.0, "pack it nicely, please");		
+		Order advancedOrder = new AdvancedOrder(null, 15.0, "pack it nicely, please", "complex package");		
+		List<Order> orders = Arrays.asList(order, advancedOrder);
+		
+		List<JsonSerializer<?>> adapters = new ArrayList<JsonSerializer<?>>();
+		adapters.add(new MyNonHierarchicalAdapter());
+
+		GsonJSONSerialization serialization = new GsonJSONSerialization(response,
+				extractor,
+				initializer,
+				adapters);
+		
+		serialization.from(orders).serialize();
+		assertThat(result(), is(equalTo(expectedResult)));		
+	}
+	
+	@HierarchicalAdapter
+	static class MyHierarchicalAdapter implements JsonSerializer<Order> {
+
+		public JsonElement serialize(Order src,
+				java.lang.reflect.Type typeOfSrc,
+				JsonSerializationContext context) {
+			return context.serialize("Order");
+		}		
+	}
+	
+	static class MyNonHierarchicalAdapter implements JsonSerializer<Order> {
+
+		public JsonElement serialize(Order src,
+				java.lang.reflect.Type typeOfSrc,
+				JsonSerializationContext context) {
+			return context.serialize("Order");
+		}		
+	}
 }


### PR DESCRIPTION
A maneira que eu encontrei foi criar um @HierarchicalAdapter. Se tiver a anotação é um adaptador hierárquico, caso contrário é um adaptador normal. 

Só me dei conta agora que isto quebra a compatibilidade. :P Se vcs considerarem a solução viável eu posso alterar e fazer um @NonHierarchicalAdapter pra não ter este problema.
